### PR TITLE
xtheadfmemidx: Fix instruction depenencies

### DIFF
--- a/xtheadfmemidx.adoc
+++ b/xtheadfmemidx.adoc
@@ -13,21 +13,20 @@ The table below gives an overview of the instructions:
 
 [cols="^3,^3,12,18",stripes=even,options="header"]
 |===
-| F    | D    | Mnemonic              | Instruction
-| Y    | Y    | th.flrd  _rd_, _rs1_, _rs2_, _imm2_ | <<#xtheadfmemidx-insns-flrd>>
-| Y    | Y    | th.flrw  _rd_, _rs1_, _rs2_, _imm2_ | <<#xtheadfmemidx-insns-flrw>>
-| N    | Y    | th.flurd _rd_, _rs1_, _rs2_, _imm2_ | <<#xtheadfmemidx-insns-flurd>>
-| N    | Y    | th.flurw _rd_, _rs1_, _rs2_, _imm2_ | <<#xtheadfmemidx-insns-flurw>>
-| Y    | Y    | th.fsrd  _rd_, _rs1_, _rs2_, _imm2_ | <<#xtheadfmemidx-insns-fsrd>>
-| Y    | Y    | th.fsrw  _rd_, _rs1_, _rs2_, _imm2_ | <<#xtheadfmemidx-insns-flrw>>
-| N    | Y    | th.fsurd _rd_, _rs1_, _rs2_, _imm2_ | <<#xtheadfmemidx-insns-fsurd>>
-| N    | Y    | th.fsurw _rd_, _rs1_, _rs2_, _imm2_ | <<#xtheadfmemidx-insns-flurw>>
+| RV32 | RV64 | F    | D    | Mnemonic              | Instruction
+| Y    | Y    | N    | Y    | th.flrd  _rd_, _rs1_, _rs2_, _imm2_ | <<#xtheadfmemidx-insns-flrd>>
+| Y    | Y    | Y    | Y    | th.flrw  _rd_, _rs1_, _rs2_, _imm2_ | <<#xtheadfmemidx-insns-flrw>>
+| N    | Y    | N    | Y    | th.flurd _rd_, _rs1_, _rs2_, _imm2_ | <<#xtheadfmemidx-insns-flurd>>
+| N    | Y    | Y    | Y    | th.flurw _rd_, _rs1_, _rs2_, _imm2_ | <<#xtheadfmemidx-insns-flurw>>
+| Y    | Y    | N    | Y    | th.fsrd  _rd_, _rs1_, _rs2_, _imm2_ | <<#xtheadfmemidx-insns-fsrd>>
+| Y    | Y    | Y    | Y    | th.fsrw  _rd_, _rs1_, _rs2_, _imm2_ | <<#xtheadfmemidx-insns-flrw>>
+| N    | Y    | N    | Y    | th.fsurd _rd_, _rs1_, _rs2_, _imm2_ | <<#xtheadfmemidx-insns-fsurd>>
+| N    | Y    | Y    | Y    | th.fsurw _rd_, _rs1_, _rs2_, _imm2_ | <<#xtheadfmemidx-insns-flurw>>
 |===
 
-All instructions are available for `RV32` and `RV64`.
-Additionally at least the `F` extension needs to be available.
-In order to have all instructions available, the `D` extensions
-needs to be implemented.
+The first four columns show the requirements of the instructions.
+E.g. `th.flurd` is only available on harts that implement the `rv64i` base
+and the `D` double-precision floating-point extensions.
 
 === Availability
 


### PR DESCRIPTION
The XTheadFMemIdx instruction that perform a zero-extension of the index register (those with a `u` in the name) are identical to the sign-extension counterparts on RV32. Therefore, it does not make sense to offer both for RV32.

Further, the table lists the 8-byte loads/stores as compatible with the `F` extensions. However, 8-byte loads won't fit into single-precision floating-point register. And 8-byte stores can't be performed from a single-precision floating-point register. Instead of defining truncation and extension for these cases, let's make the instructions only available for those cases where they make sense.

Fixes #49.