### PR TITLE
Fix typos

### DIFF
--- a/xtheadmemidx/lbuia.adoc
+++ b/xtheadmemidx/lbuia.adoc
@@ -31,7 +31,7 @@ Operation::
 [source,sail]
 --
 if (rs1 != rd) {
-    rs := zero_extend(mem[rs1])
+    rd := zero_extend(mem[rs1])
     rs1 := rs1 + (sign_extend(imm5) << imm2)
 }
 --

--- a/xtheadmemidx/ldib.adoc
+++ b/xtheadmemidx/ldib.adoc
@@ -5,7 +5,7 @@ Synopsis::
 Load indexed double-word, increment address before loading.
 
 Mnemonic::
-th.lwib _rd_, (_rs1_), _imm5_, _imm2_
+th.ldib _rd_, (_rs1_), _imm5_, _imm2_
 
 Encoding::
 [wavedrom, , svg]

--- a/xtheadsync/sync_is.adoc
+++ b/xtheadsync/sync_is.adoc
@@ -2,7 +2,7 @@
 ==== th.sync.is
 
 Synopsis::
-Ensures that all preceding instructions retire earlier than this instruction and all subsequent instructions retire later than this instruction and clears the pipeline when this instruction.
+Ensures that all preceding instructions retire earlier than this instruction and all subsequent instructions retire later than this instruction and clears the pipeline when this instruction retires.
 
 Mnemonic::
 th.sync.is


### PR DESCRIPTION
While reading the documentation, I stumbled across the following typos:
- `xtheadsync/sync_is.adoc`: incomplete synopsis
- `xtheadmemidx/lbuia.adoc`: _rs_ register should be _rd_ in the example
- `xtheadmemidx/ldib.adoc`: mnemonic shows `lwib` instead of `ldib`