### PR TITLE
Fix spelling typos in extension descriptions

### DIFF
--- a/intro.adoc
+++ b/intro.adoc
@@ -81,5 +81,5 @@ Possible states are:
 * `Stable`: No feature additions/removals/changes. Only clarifications.
 
 A `draft` specification is expected to become `stable` in the future
-(with exepcted changes until then). A `stable` extension remains in that
+(with expected changes until then). A `stable` extension remains in that
 state for ever.

--- a/xtheadbb/srriw.adoc
+++ b/xtheadbb/srriw.adoc
@@ -21,7 +21,7 @@ Encoding::
 ....
 
 Description::
-This operation performs a rotate-right on on the least-significant word of _rs1_ by _imm5_ bits and stores the result in _rd_.
+This operation performs a rotate-right on the least-significant word of _rs1_ by _imm5_ bits and stores the result in _rd_.
 
 Operation (SAIL)::
 [source,sail]

--- a/xtheadfmv.adoc
+++ b/xtheadfmv.adoc
@@ -4,7 +4,7 @@
 [NOTE,caption=Frozen]
 The `XTheadFmv` extension is `stable`.
 
-The `XTheadFmv` ISA extension provides double-precision floating-point high-bit data transmission intructions for RV32.
+The `XTheadFmv` ISA extension provides double-precision floating-point high-bit data transmission instructions for RV32.
 
 This extension depends on the availability of the `D` (double-precision floating-point) ISA extension.
 

--- a/xtheadint/ipush.adoc
+++ b/xtheadint/ipush.adoc
@@ -41,7 +41,7 @@ This instruction can be executed in `M` mode only.
 Attempts to execute this instruction in other modes will raise an illegal instruction exception.
 
 Exceptions::
-This isntruction may trigger an unaligned access exception or
+This instruction may trigger an unaligned access exception or
 an access error exception.
 
 Included in::

--- a/xtheadmae.adoc
+++ b/xtheadmae.adoc
@@ -7,11 +7,11 @@ The `XTheadMae` extension is `stable`.
 Extension version: 1.0.
 
 The `XTheadMae` ISA extension provides a way to configure memory page attributes.
-These attributes are set in the page tabale entries (PTEs).
+These attributes are set in the page table entries (PTEs).
 
 The `XTheadMae` extension is a non-standard non-conforming extension.
 `XTheadMae` uses preserved [60:63] bits of the PTE, which have later been
-allocted to the `Svpbmt` and `Svnapot` standard extensions.
+allocated to the `Svpbmt` and `Svnapot` standard extensions.
 This conflict is not on purpose, but the result of issues in the past that have been resolved since.
 Therefore, the `XTheadMae` extension and the `Svpbmt` or `Svnapot` are in conflict.
 In other words, tools should not allow to enable the `XTheadMae` extension and

--- a/xtheadsync/sync_i.adoc
+++ b/xtheadsync/sync_i.adoc
@@ -21,7 +21,7 @@ Encoding::
 ....
 
 Description::
-Besides the synopsis of th.sync, this instruction flushes the pipeline of current hart which means all subsequent instructions should be re-fectched after this instruction retires. This instruction is the only mechanism to ensure that all explicit memory accesses or cache operations visible to a hart will also be visible to its instruction fetches.
+Besides the synopsis of th.sync, this instruction flushes the pipeline of current hart which means all subsequent instructions should be re-fetched after this instruction retires. This instruction is the only mechanism to ensure that all explicit memory accesses or cache operations visible to a hart will also be visible to its instruction fetches.
 
 Operation::
 [source,sail]

--- a/xtheadvdot.adoc
+++ b/xtheadvdot.adoc
@@ -4,7 +4,7 @@
 [NOTE,caption=Frozen]
 The `XTheadVdot` extension is `stable`.
 
-The `XTheadVdot` ISA extension provides vector integer four 8-bit multiply and add with 32-bit element intructions.
+The `XTheadVdot` ISA extension provides vector integer four 8-bit multiply and add with 32-bit element instructions.
 
 This extension depends on the availability of the `V` (vector) ISA extension.
 


### PR DESCRIPTION
## What

Fixes 8 spelling mistakes in the descriptive prose of the specification:

| File | Before | After |
| --- | --- | --- |
| `intro.adoc` | with `exepcted` changes | with `expected` changes |
| `xtheadbb/srriw.adoc` | a rotate-right `on on` the least-significant word | a rotate-right `on` the least-significant word |
| `xtheadfmv.adoc` | data transmission `intructions` | data transmission `instructions` |
| `xtheadvdot.adoc` | 32-bit element `intructions` | 32-bit element `instructions` |
| `xtheadint/ipush.adoc` | This `isntruction` may trigger | This `instruction` may trigger |
| `xtheadmae.adoc` | the page `tabale` entries (PTEs) | the page `table` entries (PTEs) |
| `xtheadmae.adoc` | `allocted` to the `Svpbmt` ... | `allocated` to the `Svpbmt` ... |
| `xtheadsync/sync_i.adoc` | should be `re-fectched` | should be `re-fetched` |

## Why

These read as slips rather than intentional wording: the correct spelling is
already used consistently elsewhere in the same document. For example
"instruction" appears 648 times spelled correctly and once as "isntruction",
and "table" appears 20 times correctly and once as "tabale".

## How this was checked

- Prose only. No AsciiDoc markup, attribute, table, encoding block or SAIL
  block was touched — verified with a character-level diff audit confirming
  that the set of markup characters on each changed line is unchanged.
- `asciidoctor -d book xuantie.adoc` reports 0 errors both before and after
  this change.
- No currently open PR touches these files (#72 touches `README.md`; #57
  touches `docinfo.adoc` and `xtheadvector/intrinsics.adoc`).

There is no functional or semantic change to any instruction definition.
