### PR TITLE
RISC-V: Fix swapped instruction encodings in xtheadfmv docs

### DIFF
--- a/xtheadfmv/fmv_hw_x.adoc
+++ b/xtheadfmv/fmv_hw_x.adoc
@@ -16,7 +16,7 @@ Encoding::
     { bits:  3, name: 0x1 },
     { bits:  5, name: 'rs1' },
     { bits:  5, name: 0x0 },
-    { bits:  7, name: 0x60 },
+    { bits:  7, name: 0x50 },
 ]}
 ....
 

--- a/xtheadfmv/fmv_x_hw.adoc
+++ b/xtheadfmv/fmv_x_hw.adoc
@@ -16,7 +16,7 @@ Encoding::
     { bits:  3, name: 0x1 },
     { bits:  5, name: 'fs1' },
     { bits:  5, name: 0x0 },
-    { bits:  7, name: 0x50 },
+    { bits:  7, name: 0x60 },
 ]}
 ....
 


### PR DESCRIPTION
The documentation for the th.fmv.hw.x and th.fmv.x.hw instructions incorrectly swapped their 7-bit opcode fields.  This patch corrects the encoding tables to match the actual hardware specifications.

ChangeLog:
	* xtheadfmv/fmv_hw_x.adoc: Correct funct7 opcode from 0x60 to 0x50.
	* xtheadfmv/fmv_x_hw.adoc: Correct funct7 opcode from 0x50 to 0x60.