### PR TITLE
CI: Remove unsupported npm --unsafe flag

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,7 @@ jobs:
         sudo gem install coderay
         sudo npm i npm@latest -g
         sudo npm install -g bytefield-svg
-        sudo npm install -g wavedrom-cli --unsafe
+        sudo npm install -g wavedrom-cli
         export PATH="$PATH:node_modules/.bin/"
 
     - name: Build


### PR DESCRIPTION
npm 12 rejects the obsolete --unsafe flag instead of ignoring it.  Remove the flag so wavedrom-cli installation can complete and the specification build can run.